### PR TITLE
feat(27): 로그인, 회원가입 관련 API 연결

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@types/react": "^18",
     "@types/react-dom": "^18",
     "autoprefixer": "^10.4.21",
+    "cookies-next": "^5.1.0",
     "eslint": "^9",
     "eslint-plugin-prettier": "^5.2.6",
     "next-pwa": "^5.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,6 +81,9 @@ importers:
       autoprefixer:
         specifier: ^10.4.21
         version: 10.4.21(postcss@8.5.3)
+      cookies-next:
+        specifier: ^5.1.0
+        version: 5.1.0(next@14.2.28(@babel/core@7.26.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
       eslint:
         specifier: ^9
         version: 9.25.1(jiti@1.21.7)
@@ -1532,6 +1535,16 @@ packages:
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie@1.0.2:
+    resolution: {integrity: sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==}
+    engines: {node: '>=18'}
+
+  cookies-next@5.1.0:
+    resolution: {integrity: sha512-9Ekne+q8hfziJtnT9c1yDUBqT0eDMGgPrfPl4bpR3xwQHLTd/8gbSf6+IEkP/pjGsDZt1TGbC6emYmFYRbIXwQ==}
+    peerDependencies:
+      next: '>=15.0.0'
+      react: '>= 16.8.0'
 
   core-js-compat@3.42.0:
     resolution: {integrity: sha512-bQasjMfyDGyaeWKBIu33lHh9qlSR0MFE/Nmc6nMjf/iU9b3rSMdAYz1Baxrv4lPdGUsTqZudHA4jIGSJy0SWZQ==}
@@ -4849,6 +4862,14 @@ snapshots:
   concat-map@0.0.1: {}
 
   convert-source-map@2.0.0: {}
+
+  cookie@1.0.2: {}
+
+  cookies-next@5.1.0(next@14.2.28(@babel/core@7.26.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1):
+    dependencies:
+      cookie: 1.0.2
+      next: 14.2.28(@babel/core@7.26.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
 
   core-js-compat@3.42.0:
     dependencies:

--- a/src/app/(auth)/policy/_components/PolicyContainer.tsx
+++ b/src/app/(auth)/policy/_components/PolicyContainer.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/common/button";
 import { useRouter } from "next/navigation";
 import { POLICY_LIST } from "./constants";
 import { ZaplyColorLogoIcon } from "@/components/icons/logo";
+import { useSignUpStore } from "@/stores/useSignUpStore";
 
 const PolicyContainer = () => {
   const router = useRouter();
@@ -17,6 +18,18 @@ const PolicyContainer = () => {
     setRequiredCheck,
     setOptionalChecked,
   } = usePolicyStore();
+
+  const setAgreements = useSignUpStore(state => state.setAgreements);
+
+  const handleNext = () => {
+    setAgreements({
+      termsOfServiceAgreed: requiredChecks[0],
+      privacyPolicyAgreed: requiredChecks[1],
+      marketingAgreed: optionalChecked,
+    });
+
+    router.push("/sign-up?state=EMAIL");
+  };
 
   return (
     <article className="flex flex-col justify-between min-h-real-screen pb-[56px]">
@@ -49,7 +62,7 @@ const PolicyContainer = () => {
       <Button
         variant={requiredChecks.every(check => check) ? "active" : "deactive"}
         disabled={!requiredChecks.every(check => check)}
-        onClick={() => router.push("/sign-up?state=EMAIL")}>
+        onClick={handleNext}>
         다음
       </Button>
     </article>

--- a/src/app/(auth)/sign-in/_components/SignInForm.tsx
+++ b/src/app/(auth)/sign-in/_components/SignInForm.tsx
@@ -36,26 +36,22 @@ const SignInForm = () => {
     const { email, password } = data;
 
     try {
-      // const passwordCorrect = false;
-      const res = await authService.login({ email: email, password: password });
-
-      if (res.result === "ERROR") {
-        const message = "가입되지 않은 정보예요.";
+      const isEmailExists = await authService.checkEmailDuplicate(email);
+      if (!isEmailExists) {
+        const message = "계정 정보가 존재하지 않습니다.";
         setError("email", { type: "manual", message });
         toast({ variant: "error", description: message });
         return;
       }
 
-      // if (!passwordCorrect) {
-      //   const message = "아이디 또는 비밀번호가 맞지 않아요.\n다시 확인해주세요.";
-      //   setError("password", { type: "manual", message });
-      //   toast({ variant: "error", description: message });
-      //   return;
-      // }
+      await authService.login({ email, password });
 
       router.push("/");
     } catch (err) {
-      console.error("로그인 실패", err);
+      toast({
+        variant: "error",
+        description: `비밀번호가 맞지 않아요.\n다시 확인해주세요.`,
+      });
     }
   };
 

--- a/src/app/(auth)/sign-in/_components/SignInForm.tsx
+++ b/src/app/(auth)/sign-in/_components/SignInForm.tsx
@@ -1,14 +1,15 @@
 "use client";
 
-import { useForm, FieldValues } from "react-hook-form";
+import { useForm } from "react-hook-form";
 import { z } from "zod";
-import { UseFormSetError } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import Link from "next/link";
 import { useToast } from "@/utils/useToast";
 import { Button } from "@/components/common/button";
 import { Input } from "@/components/common/input";
 import { emailCheckSchema } from "@/lib/zod";
+import { authService } from "@/lib/api/service";
+import { useRouter } from "next/navigation";
 
 const schema = emailCheckSchema.extend({
   password: z.string().min(1, "비밀번호를 입력해 주세요."),
@@ -26,30 +27,33 @@ const SignInForm = () => {
   });
 
   const { toast } = useToast();
+  const router = useRouter();
   const email = watch("email") ?? "";
   const password = watch("password") ?? "";
   const isInputFilled = email.trim() !== "" && password.trim() !== "";
 
-  const handleSignInSubmit = async (data: FieldValues, setError: UseFormSetError<any>) => {
-    try {
-      const userExists = false;
-      const passwordCorrect = false;
+  const handleSignInSubmit = async (data: FormData, setError: any) => {
+    const { email, password } = data;
 
-      if (!userExists) {
-        const message = "가입되지 않은 이메일 주소예요.";
+    try {
+      // const passwordCorrect = false;
+      const res = await authService.login({ email: email, password: password });
+
+      if (res.result === "ERROR") {
+        const message = "가입되지 않은 정보예요.";
         setError("email", { type: "manual", message });
         toast({ variant: "error", description: message });
         return;
       }
 
-      if (!passwordCorrect) {
-        const message = "아이디 또는 비밀번호가 맞지 않아요.\n다시 확인해주세요.";
-        setError("password", { type: "manual", message });
-        toast({ variant: "error", description: message });
-        return;
-      }
+      // if (!passwordCorrect) {
+      //   const message = "아이디 또는 비밀번호가 맞지 않아요.\n다시 확인해주세요.";
+      //   setError("password", { type: "manual", message });
+      //   toast({ variant: "error", description: message });
+      //   return;
+      // }
 
-      console.log("로그인 성공", data);
+      router.push("/");
     } catch (err) {
       console.error("로그인 실패", err);
     }

--- a/src/app/(auth)/sign-up-complete/page.tsx
+++ b/src/app/(auth)/sign-up-complete/page.tsx
@@ -5,10 +5,13 @@ import { Button } from "@/components/common/button";
 import { ArrowIcon } from "@/components/icons";
 import { motion } from "framer-motion";
 import { fadeUpVariants, transition } from "./_animation";
+import { useRouter } from "next/navigation";
 
 export default function SignInCompletePage() {
+  const router = useRouter();
+
   return (
-    <Container className="bg-center bg-cover bg-background-line">
+    <Container className="bg-center bg-cover bg-backgroundLine-yellow">
       <div className="flex flex-col justify-between min-h-real-screen pb-[56px]">
         <motion.div
           variants={fadeUpVariants}
@@ -28,7 +31,7 @@ export default function SignInCompletePage() {
             className="w-full">
             <Button
               variant={"subAction"}
-              onClick={() => null}
+              onClick={() => router.push("/")}
               className="border border-grayscale-300">
               <p className="text-button1">건너뛰기</p>
             </Button>

--- a/src/app/(auth)/sign-up/_components/email/EmailCheckWrapper.tsx
+++ b/src/app/(auth)/sign-up/_components/email/EmailCheckWrapper.tsx
@@ -8,6 +8,7 @@ import { useForm } from "react-hook-form";
 import { useToast } from "@/utils/useToast";
 import EmailForm from "./EmailForm";
 import { useSignUpStore } from "@/stores/useSignUpStore";
+import { authService } from "@/lib/api/service";
 
 const EmailCheckWrapper = () => {
   const router = useRouter();
@@ -22,17 +23,26 @@ const EmailCheckWrapper = () => {
   } = formMethods;
 
   const handleSubmit = () => {
-    formMethods.handleSubmit(data => {
-      useSignUpStore.getState().setEmail(data.email);
-      // console.log("이메일" + data.email);
+    formMethods.handleSubmit(async data => {
+      try {
+        const isDuplicate = await authService.checkEmailDuplicate(data.email);
+        if (isDuplicate) {
+          toast({
+            variant: "error",
+            description: `이미 가입된 이메일입니다.\n다른 이메일로 가입해주세요.`,
+          });
+          return;
+        }
 
-      /** api 호출 로직 추후 구현 */
-
-      // toast({
-      //   variant: "error",
-      //   description: `이미 가입된 이메일입니다.\n 다른 이메일로 가입해주세요.`,
-      // });
-      router.push("/sign-up?state=PASSWORD");
+        useSignUpStore.getState().setEmail(data.email);
+        router.push("/sign-up?state=PASSWORD");
+      } catch (err) {
+        toast({
+          variant: "error",
+          description: `이메일 확인 중 문제가 발생했습니다.`,
+        });
+        console.error(err);
+      }
     })();
   };
 

--- a/src/app/(auth)/sign-up/_components/email/EmailCheckWrapper.tsx
+++ b/src/app/(auth)/sign-up/_components/email/EmailCheckWrapper.tsx
@@ -7,6 +7,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 import { useToast } from "@/utils/useToast";
 import EmailForm from "./EmailForm";
+import { useSignUpStore } from "@/stores/useSignUpStore";
 
 const EmailCheckWrapper = () => {
   const router = useRouter();
@@ -22,6 +23,7 @@ const EmailCheckWrapper = () => {
 
   const handleSubmit = () => {
     formMethods.handleSubmit(data => {
+      useSignUpStore.getState().setEmail(data.email);
       // console.log("이메일" + data.email);
 
       /** api 호출 로직 추후 구현 */

--- a/src/app/(auth)/sign-up/_components/password/PasswordCheckWrapper.tsx
+++ b/src/app/(auth)/sign-up/_components/password/PasswordCheckWrapper.tsx
@@ -12,6 +12,7 @@ import {
   passwordCheckSchema,
   passwordCheckType,
 } from "@/lib/zod/schema-password";
+import { useSignUpStore } from "@/stores/useSignUpStore";
 
 const PasswordCheckWrapper = () => {
   const router = useRouter();
@@ -31,6 +32,7 @@ const PasswordCheckWrapper = () => {
 
   const handleSubmit = () => {
     formMethods.handleSubmit(data => {
+      useSignUpStore.getState().setPassword(data.password);
       // console.log(data.password);
       // console.log(data.passwordConfirm);
 

--- a/src/app/(auth)/sign-up/_components/userInfo/UserInfoForm.tsx
+++ b/src/app/(auth)/sign-up/_components/userInfo/UserInfoForm.tsx
@@ -97,9 +97,9 @@ const UserInfoForm = ({
     const verifyCode = watch("verifyCode");
 
     try {
-      const result = await smsService.certifySms({ phoneNum: phoneNumber, authNum: verifyCode });
+      const res = await smsService.certifySms({ phoneNum: phoneNumber, authNum: verifyCode });
 
-      if (result.data === "SUCCESS") {
+      if (res.result === "SUCCESS") {
         toast({
           variant: "check",
           description: `인증이 완료되었습니다.`,

--- a/src/app/(auth)/sign-up/_components/userInfo/UserInfoForm.tsx
+++ b/src/app/(auth)/sign-up/_components/userInfo/UserInfoForm.tsx
@@ -7,8 +7,17 @@ import useAutoFocus from "../hooks/useAutoFocus";
 import { useToast } from "@/utils/useToast";
 import { cn } from "@/utils";
 import useTimer from "../hooks/useTimer";
+import smsService from "@/lib/api/service/SmsService";
 
-const UserInfoForm = ({ formMethods }: { formMethods: UseFormReturn<userInfoType> }) => {
+const UserInfoForm = ({
+  formMethods,
+  checkVerifyCode,
+  setCheckVerifyCode,
+}: {
+  formMethods: UseFormReturn<userInfoType>;
+  checkVerifyCode: boolean;
+  setCheckVerifyCode: (value: boolean) => void;
+}) => {
   const { toast } = useToast();
   const { register, setValue, watch, formState } = formMethods;
 
@@ -20,7 +29,6 @@ const UserInfoForm = ({ formMethods }: { formMethods: UseFormReturn<userInfoType
 
   const [isSendVerifyCode, setIsSendVerifyCode] = useState(false);
   const [isPhoneNumberValid, setIsPhoneNumberValid] = useState(false);
-  const [checkVerifyCode, setCheckVerifyCode] = useState(false);
 
   const { formatTimer } = useTimer({
     defaultTime: 180,
@@ -64,33 +72,51 @@ const UserInfoForm = ({ formMethods }: { formMethods: UseFormReturn<userInfoType
     [setValue]
   );
 
-  const handleSendVerifyCode = () => {
-    /** 인증번호 호출 api 로직 구현 */
+  const handleSendVerifyCode = async () => {
     const phoneNumber = watch("phoneNumber");
 
-    toast({
-      variant: "default",
-      description: `인증번호가 전송되었습니다.\n 문자를 확인하고 인증번호를 입력해주세요.`,
-    });
-    setIsSendVerifyCode(true);
-  };
+    try {
+      await smsService.sendSms({ phoneNum: phoneNumber });
 
-  const handleCheckVerifyCode = () => {
-    /** 인증번호 검증 api 로직 구현 */
-    const verifyCode = watch("verifyCode");
-
-    /** 테스트 용 로직 */
-    if (verifyCode === "123456") {
       toast({
-        variant: "check",
-        description: `인증이 완료되었습니다.`,
+        variant: "default",
+        description: `인증번호가 전송되었습니다.\n 문자를 확인하고 인증번호를 입력해주세요.`,
       });
-      setCheckVerifyCode(true);
-    } else {
+      setIsSendVerifyCode(true);
+    } catch (err) {
       toast({
         variant: "error",
-        description: `인증번호가 잘못되었습니다.`,
+        description: `인증번호 전송에 실패했습니다.`,
       });
+      console.error("인증번호 전송 실패:", err);
+    }
+  };
+
+  const handleCheckVerifyCode = async () => {
+    const phoneNumber = watch("phoneNumber");
+    const verifyCode = watch("verifyCode");
+
+    try {
+      const result = await smsService.certifySms({ phoneNum: phoneNumber, authNum: verifyCode });
+
+      if (result.data === "SUCCESS") {
+        toast({
+          variant: "check",
+          description: `인증이 완료되었습니다.`,
+        });
+        setCheckVerifyCode(true);
+      } else {
+        toast({
+          variant: "error",
+          description: `인증번호가 잘못되었습니다.`,
+        });
+      }
+    } catch (err) {
+      toast({
+        variant: "error",
+        description: `인증번호 검증에 실패했습니다.`,
+      });
+      console.error("인증번호 검증 실패:", err);
     }
   };
 

--- a/src/app/(auth)/sign-up/_components/userInfo/UserInfoWrapper.tsx
+++ b/src/app/(auth)/sign-up/_components/userInfo/UserInfoWrapper.tsx
@@ -8,6 +8,8 @@ import UserInfoForm from "./UserInfoForm";
 import { userInfoType, userInfoSchema } from "@/lib/zod";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useState } from "react";
+import { authController } from "@/lib/api/controller";
+import { useSignUpStore } from "@/stores/useSignUpStore";
 
 const UserInfoWrapper = () => {
   const router = useRouter();
@@ -25,9 +27,31 @@ const UserInfoWrapper = () => {
   } = formMethods;
 
   const handleSubmit = () => {
-    formMethods.handleSubmit(data => {
-      console.log(data);
-      router.push("/sign-up-complete");
+    formMethods.handleSubmit(async data => {
+      try {
+        const { email, password, termsOfServiceAgreed, privacyPolicyAgreed, marketingAgreed } =
+          useSignUpStore.getState(); // 상태에서 가져옴
+
+        const requestBody = {
+          email,
+          password,
+          phoneNumber: data.phoneNumber,
+          residentNumber: `${data.frontRRN}-${data.backRRN}`,
+          termsOfServiceAgreed,
+          privacyPolicyAgreed,
+          marketingAgreed,
+        };
+
+        await authController.signUp(requestBody);
+        useSignUpStore.getState().reset();
+        router.push("/sign-up-complete");
+      } catch (err) {
+        toast({
+          variant: "error",
+          description: `회원가입에 실패했습니다. \n 다시 시도해주세요.`,
+        });
+        console.error("회원가입 에러:", err);
+      }
     })();
   };
 

--- a/src/app/(auth)/sign-up/_components/userInfo/UserInfoWrapper.tsx
+++ b/src/app/(auth)/sign-up/_components/userInfo/UserInfoWrapper.tsx
@@ -7,10 +7,14 @@ import { useToast } from "@/utils/useToast";
 import UserInfoForm from "./UserInfoForm";
 import { userInfoType, userInfoSchema } from "@/lib/zod";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { useState } from "react";
 
 const UserInfoWrapper = () => {
   const router = useRouter();
   const { toast } = useToast();
+
+  const [checkVerifyCode, setCheckVerifyCode] = useState(false);
+
   const formMethods = useForm<userInfoType>({
     resolver: zodResolver(userInfoSchema),
     mode: "onChange",
@@ -23,7 +27,6 @@ const UserInfoWrapper = () => {
   const handleSubmit = () => {
     formMethods.handleSubmit(data => {
       console.log(data);
-      /** api 호출 로직 추후 구현 */
       router.push("/sign-up-complete");
     })();
   };
@@ -31,9 +34,16 @@ const UserInfoWrapper = () => {
   return (
     <article className="flex flex-col justify-between min-h-real-screen pb-[56px]">
       <div className="pt-[139px] flex flex-col space-y-3">
-        <UserInfoForm formMethods={formMethods} />
+        <UserInfoForm
+          formMethods={formMethods}
+          checkVerifyCode={checkVerifyCode}
+          setCheckVerifyCode={setCheckVerifyCode}
+        />
       </div>
-      <Button variant={isValid ? "active" : "deactive"} onClick={handleSubmit} disabled={!isValid}>
+      <Button
+        variant={isValid && checkVerifyCode ? "active" : "deactive"}
+        onClick={handleSubmit}
+        disabled={!isValid || !checkVerifyCode}>
         다음
       </Button>
     </article>

--- a/src/components/icons/service/index.tsx
+++ b/src/components/icons/service/index.tsx
@@ -495,30 +495,30 @@ export const FollowersIcon = ({
     className={className}
     {...props}>
     <path
-      fill-rule="evenodd"
-      clip-rule="evenodd"
+      fillRule="evenodd"
+      clipRule="evenodd"
       d="M13.9761 7.36049C13.9761 9.70533 12.075 11.6053 9.73137 11.6053C7.38654 11.6053 5.48535 9.70533 5.48535 7.36049C5.48535 5.01565 7.38654 3.11572 9.73137 3.11572C12.075 3.11572 13.9761 5.01565 13.9761 7.36049Z"
       stroke={stroke}
-      stroke-width="1.4"
-      stroke-linecap="square"
+      strokeWidth="1.4"
+      strokeLinecap="square"
     />
     <path
       d="M13.9068 5.73099C14.5 5.07681 15.3568 4.66602 16.3096 4.66602C18.0991 4.66602 19.5509 6.11679 19.5509 7.90729C19.5509 9.69778 18.0991 11.1486 16.3096 11.1486C15.167 11.1486 14.1624 10.5578 13.585 9.66499"
       stroke={stroke}
-      stroke-width="1.4"
-      stroke-linecap="square"
+      strokeWidth="1.4"
+      strokeLinecap="square"
     />
     <path
       d="M9.76408 14.7071C12.8915 14.6991 15.5507 16.135 16.5282 19.2261C14.558 20.4272 12.2389 20.8898 9.76408 20.8837C7.28921 20.8898 4.97016 20.4272 3 19.2261C3.97857 16.1317 6.63327 14.6991 9.76408 14.7071Z"
       stroke={stroke}
-      stroke-width="1.4"
-      stroke-linecap="square"
+      strokeWidth="1.4"
+      strokeLinecap="square"
     />
     <path
       d="M16.3352 18.2323C18.225 18.237 19.9958 17.8837 21.5002 16.9666C20.7539 14.6063 18.7233 13.5098 16.3352 13.5159C14.8309 13.512 13.4705 13.9438 12.4824 14.8531"
       stroke={stroke}
-      stroke-width="1.4"
-      stroke-linecap="square"
+      strokeWidth="1.4"
+      strokeLinecap="square"
     />
   </svg>
 );
@@ -1187,7 +1187,7 @@ export const TagIcon = ({
     />
     <path
       fillRule="evenodd"
-      clip-rule="evenodd"
+      clipRule="evenodd"
       d="M8.41421 18C8.149 18 7.89464 17.8946 7.70711 17.7071L2 12L7.70711 6.29289C7.89464 6.10536 8.149 6 8.41421 6H20C21.1046 6 22 6.89543 22 8V16C22 17.1046 21.1046 18 20 18H8.41421Z"
       stroke={stroke}
       strokeWidth="1.4"
@@ -1582,8 +1582,8 @@ export const PlusIcon = ({
     fill="none"
     className={className}
     {...props}>
-    <path d="M21 11H1" stroke={stroke} stroke-width="1.4" stroke-linecap="round" />
-    <path d="M11 21V1" stroke={stroke} stroke-width="1.4" stroke-linecap="round" />
+    <path d="M21 11H1" stroke={stroke} strokeWidth="1.4" strokeLinecap="round" />
+    <path d="M11 21V1" stroke={stroke} strokeWidth="1.4" strokeLinecap="round" />
   </svg>
 );
 
@@ -1604,18 +1604,18 @@ export const TimeIcon = ({
     className={className}
     {...props}>
     <path
-      fill-rule="evenodd"
-      clip-rule="evenodd"
+      fillRule="evenodd"
+      clipRule="evenodd"
       d="M17.9167 10.4998C17.9167 14.7573 14.4658 18.2082 10.2083 18.2082C5.95083 18.2082 2.5 14.7573 2.5 10.4998C2.5 6.24234 5.95083 2.7915 10.2083 2.7915C14.4658 2.7915 17.9167 6.24234 17.9167 10.4998Z"
       stroke={stroke}
-      stroke-width="1.16667"
-      stroke-linecap="square"
+      strokeWidth="1.16667"
+      strokeLinecap="square"
     />
     <path
       d="M13.0684 12.9519L9.92676 11.0777V7.03857"
       stroke={stroke}
-      stroke-width="1.16667"
-      stroke-linecap="square"
+      strokeWidth="1.16667"
+      strokeLinecap="square"
     />
   </svg>
 );

--- a/src/lib/api/axios/tokenManager.ts
+++ b/src/lib/api/axios/tokenManager.ts
@@ -1,38 +1,32 @@
-import { cookies } from "next/headers";
+import { getCookie, setCookie, deleteCookie } from "cookies-next";
 
 const ACCESS_TOKEN_KEY = "access_token";
 const REFRESH_TOKEN_KEY = "refresh_token";
 
 export const tokenManager = {
   setTokens: (accessToken: string, refreshToken: string) => {
-    const cookieStore = cookies();
-    cookieStore.set(ACCESS_TOKEN_KEY, accessToken, {
-      httpOnly: true,
+    setCookie(ACCESS_TOKEN_KEY, accessToken, {
+      path: "/",
       secure: process.env.NODE_ENV === "production",
       sameSite: "lax",
-      path: "/",
     });
-    cookieStore.set(REFRESH_TOKEN_KEY, refreshToken, {
-      httpOnly: true,
+    setCookie(REFRESH_TOKEN_KEY, refreshToken, {
+      path: "/",
       secure: process.env.NODE_ENV === "production",
       sameSite: "lax",
-      path: "/",
     });
   },
 
-  getAccessToken: () => {
-    const cookieStore = cookies();
-    return cookieStore.get(ACCESS_TOKEN_KEY)?.value;
+  getAccessToken: (): string | undefined => {
+    return getCookie(ACCESS_TOKEN_KEY)?.toString();
   },
 
-  getRefreshToken: () => {
-    const cookieStore = cookies();
-    return cookieStore.get(REFRESH_TOKEN_KEY)?.value;
+  getRefreshToken: (): string | undefined => {
+    return getCookie(REFRESH_TOKEN_KEY)?.toString();
   },
 
   removeTokens: () => {
-    const cookieStore = cookies();
-    cookieStore.delete(ACCESS_TOKEN_KEY);
-    cookieStore.delete(REFRESH_TOKEN_KEY);
+    deleteCookie(ACCESS_TOKEN_KEY);
+    deleteCookie(REFRESH_TOKEN_KEY);
   },
 };

--- a/src/lib/api/controller/AuthController.ts
+++ b/src/lib/api/controller/AuthController.ts
@@ -17,6 +17,13 @@ const authController = {
     return response.data;
   },
 
+  checkEmailDuplicate: async (email: string): Promise<ApiResponse<boolean>> => {
+    const response = await apiClient.get<ApiResponse<boolean>>("/auth/email/duplicate", {
+      params: { email },
+    });
+    return response.data;
+  },
+
   refreshToken: async (): Promise<ApiResponse<LoginData>> => {
     const response = await apiClient.get<ApiResponse<LoginData>>("/auth/recreate");
     return response.data;

--- a/src/lib/api/controller/SmsController.ts
+++ b/src/lib/api/controller/SmsController.ts
@@ -1,0 +1,17 @@
+import { apiClient } from "../axios/instance";
+import { ApiResponse } from "../model/response";
+import { CertificationSmsRequest, SendSmsRequest } from "../model/sms";
+
+const smsController = {
+  sendSms: async (data: SendSmsRequest): Promise<ApiResponse<null>> => {
+    const response = await apiClient.post<ApiResponse<null>>("/sms/send", data);
+    return response.data;
+  },
+
+  certifySms: async (data: CertificationSmsRequest): Promise<ApiResponse<string>> => {
+    const response = await apiClient.post<ApiResponse<string>>("/sms/certification", data);
+    return response.data;
+  },
+};
+
+export default smsController;

--- a/src/lib/api/model/sms.ts
+++ b/src/lib/api/model/sms.ts
@@ -1,0 +1,8 @@
+export interface SendSmsRequest {
+  phoneNum: string;
+}
+
+export interface CertificationSmsRequest {
+  phoneNum: string;
+  authNum: string;
+}

--- a/src/lib/api/service/AuthService.ts
+++ b/src/lib/api/service/AuthService.ts
@@ -37,6 +37,16 @@ const authService = {
     }
   },
 
+  checkEmailDuplicate: async (email: string): Promise<boolean> => {
+    try {
+      const response = await authController.checkEmailDuplicate(email);
+      return response.data;
+    } catch (error) {
+      console.error("Email duplicate check failed:", error);
+      throw new Error(error as string);
+    }
+  },
+
   refreshToken: async (): Promise<ApiResponse<LoginData>> => {
     try {
       const response = await authController.refreshToken();

--- a/src/lib/api/service/SmsService.ts
+++ b/src/lib/api/service/SmsService.ts
@@ -1,0 +1,27 @@
+import smsController from "../controller/SmsController";
+import { ApiResponse } from "../model";
+import { CertificationSmsRequest, SendSmsRequest } from "../model/sms";
+
+const smsService = {
+  sendSms: async (data: SendSmsRequest): Promise<ApiResponse<null>> => {
+    try {
+      const response = await smsController.sendSms(data);
+      return response;
+    } catch (error) {
+      console.error("SMS 전송 실패:", error);
+      throw new Error("인증번호 전송에 실패했습니다.");
+    }
+  },
+
+  certifySms: async (data: CertificationSmsRequest): Promise<ApiResponse<string>> => {
+    try {
+      const response = await smsController.certifySms(data);
+      return response;
+    } catch (error) {
+      console.error("SMS 인증 실패:", error);
+      throw new Error("인증번호 확인에 실패했습니다.");
+    }
+  },
+};
+
+export default smsService;

--- a/src/stores/useSignUpStore.ts
+++ b/src/stores/useSignUpStore.ts
@@ -1,0 +1,46 @@
+import { create } from "zustand";
+
+interface SignUpState {
+  name: string;
+  email: string;
+  password: string;
+  phoneNumber: string;
+  residentNumber: string;
+  termsOfServiceAgreed: boolean;
+  privacyPolicyAgreed: boolean;
+  marketingAgreed: boolean;
+  setEmail: (email: string) => void;
+  setPassword: (password: string) => void;
+  setAgreements: (options: {
+    termsOfServiceAgreed: boolean;
+    privacyPolicyAgreed: boolean;
+    marketingAgreed: boolean;
+  }) => void;
+  reset: () => void;
+}
+
+export const useSignUpStore = create<SignUpState>(set => ({
+  name: "",
+  email: "",
+  password: "",
+  phoneNumber: "",
+  residentNumber: "",
+  termsOfServiceAgreed: false,
+  privacyPolicyAgreed: false,
+  marketingAgreed: false,
+  setEmail: email => set({ email }),
+  setPassword: password => set({ password }),
+  setAgreements: ({ termsOfServiceAgreed, privacyPolicyAgreed, marketingAgreed }) =>
+    set({ termsOfServiceAgreed, privacyPolicyAgreed, marketingAgreed }),
+  reset: () =>
+    set({
+      name: "",
+      email: "",
+      password: "",
+      phoneNumber: "",
+      residentNumber: "",
+      termsOfServiceAgreed: false,
+      privacyPolicyAgreed: false,
+      marketingAgreed: false,
+    }),
+}));


### PR DESCRIPTION
## 🔎 작업 내용

- 회원가입은 단계 별로 분리되어 있어서 값을 store에 저장해서 API 요청 보내도록 했습니다. (다른 좋은 방법이 있다면 리뷰 남겨주세영~)
- 로그인은 기존 ```AuthService```에 있던 로직 사용했고, 인증번호 전송, 검증 부분은 ```SmsController```, ```SmsService``` 에 작성해서 API 요청하도록 했습니다!
- next/headers -> cookies-next 사용하도록 변경
- 아이콘 파일에서 - 때문에 콘솔에 엄청 경고 뜨길래 수정

  <br/>

## 이미지 첨부

- 회원가입

https://github.com/user-attachments/assets/b9b93a66-3030-4e6e-b577-3d2424bb3cb3

<br />

- 로그인

https://github.com/user-attachments/assets/d91a72d8-759c-461a-b504-f59de4251f9d


<br/>

## 🔧 앞으로의 과제

- 인사이트쪽 디자인이나온 거 같은데 여기를 해보ㄹ까요...

  <br/>

## ➕ 이슈 링크

- #27 

<br/>
